### PR TITLE
Fix repo links, format with existing Prettier settings

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://github.com/sw-yx/react-typescript-cheatsheet/issues/81">
+<a href="https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/81">
   <img
     height="90"
     width="90"
@@ -12,13 +12,13 @@
 
 <p>Cheatsheets for experienced React developers getting started with TypeScript</p>
 
-[**Basic**](https://github.com/sw-yx/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
-[**Advanced**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
-[**Migrating**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
-[**HOC**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/HOC.md) |
+[**Basic**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
+[**Advanced**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
+[**Migrating**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
+[**HOC**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/HOC.md) |
 [中文翻译](https://github.com/fi3ework/blog/tree/master/react-typescript-cheatsheet-cn) |
-[Contribute!](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
-[Ask!](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new/choose)
+[Contribute!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
+[Ask!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new/choose)
 
 </div>
 
@@ -137,7 +137,7 @@ export function withTheme<T extends WithThemeProps = WithThemeProps>(
 ) {
   // Try to create a nice displayName for React Dev Tools.
   const displayName =
-    WrappedComponent.displayName || WrappedComponent.name || "Component";
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
   // Creating the inner component. The calculated Props type here is the where the magic happens.
   return class ComponentWithTheme extends React.Component<
@@ -174,7 +174,7 @@ export function inject<TProps, TInjectedKeys extends keyof TProps>(
 
 ### Using `forwardRef`
 
-For "true" reusability you should also consider exposing a ref for your HOC. You can use `React.forwardRef<Ref, Props>` as documented in [the basic cheatsheet](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/README.md#forwardrefcreateref), but we are interested in more real world examples. [Here is a nice example in practice](https://gist.github.com/OliverJAsh/d2f462b03b3e6c24f5588ca7915d010e) from @OliverJAsh.
+For "true" reusability you should also consider exposing a ref for your HOC. You can use `React.forwardRef<Ref, Props>` as documented in [the basic cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/README.md#forwardrefcreateref), but we are interested in more real world examples. [Here is a nice example in practice](https://gist.github.com/OliverJAsh/d2f462b03b3e6c24f5588ca7915d010e) from @OliverJAsh.
 
 ## Render Props
 
@@ -203,7 +203,7 @@ export interface Props {
 }
 ```
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## `as` props (passing a component to be rendered)
 
@@ -217,7 +217,7 @@ function PassThrough(props: { as: React.ElementType<any> }) {
 }
 ```
 
-[Thanks @eps1lon](https://github.com/sw-yx/react-typescript-cheatsheet/pull/69) for this
+[Thanks @eps1lon](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/69) for this
 
 ## Typing a Component that Accepts Different Props
 
@@ -226,14 +226,14 @@ Components, and JSX in general, are analogous to functions. When a component can
 A very common use case for this is to render something as either a button or an anchor, based on if it receives a `href` attribute.
 
 ```tsx
-type ButtonProps = JSX.IntrinsicElements["button"];
-type AnchorProps = JSX.IntrinsicElements["a"];
+type ButtonProps = JSX.IntrinsicElements['button'];
+type AnchorProps = JSX.IntrinsicElements['a'];
 
 // optionally use a custom type guard
 function isPropsForAnchorElement(
   props: ButtonProps | AnchorProps
 ): props is AnchorProps {
-  return "href" in props;
+  return 'href' in props;
 }
 
 function Clickable(props: ButtonProps | AnchorProps) {
@@ -248,10 +248,10 @@ function Clickable(props: ButtonProps | AnchorProps) {
 They don't even need to be completely different props, as long as they have at least one difference in properties:
 
 ```tsx
-type LinkProps = Omit<JSX.IntrinsicElements["a"], "href"> & { to?: string };
+type LinkProps = Omit<JSX.IntrinsicElements['a'], 'href'> & { to?: string };
 
 function RouterLink(props: LinkProps | AnchorProps) {
-  if ("to" in props) {
+  if ('to' in props) {
     return <a {...props} />;
   } else {
     return <Link {...props} />;
@@ -262,7 +262,7 @@ function RouterLink(props: LinkProps | AnchorProps) {
 <details>
   <summary><b>Approach: Generic Components</b></summary>
   
-  Here is an example solution, see the further discussion for other solutions. *thanks to [@jpavon](https://github.com/sw-yx/react-typescript-cheatsheet/issues/12#issuecomment-394440577)*
+  Here is an example solution, see the further discussion for other solutions. *thanks to [@jpavon](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/12#issuecomment-394440577)*
   
 ```tsx
 interface LinkProps {}
@@ -333,7 +333,7 @@ type UserTextEvent = { value: string; target: HTMLInputElement };
 type UserMouseEvent = { value: [number, number]; target: HTMLElement };
 type UserEvent = UserTextEvent | UserMouseEvent;
 function handle(event: UserEvent) {
-  if (typeof event.value === "string") {
+  if (typeof event.value === 'string') {
     event.value; // string
     event.target; // HTMLInputElement | HTMLElement (!!!!)
     return;
@@ -347,18 +347,18 @@ Even though we have narrowed based on `event.value`, the logic doesn't filter up
 
 ```ts
 type UserTextEvent = {
-  type: "TextEvent";
+  type: 'TextEvent';
   value: string;
   target: HTMLInputElement;
 };
 type UserMouseEvent = {
-  type: "MouseEvent";
+  type: 'MouseEvent';
   value: [number, number];
   target: HTMLElement;
 };
 type UserEvent = UserTextEvent | UserMouseEvent;
 function handle(event: UserEvent) {
-  if (event.type === "TextEvent") {
+  if (event.type === 'TextEvent') {
     event.value; // string
     event.target; // HTMLInputElement
     return;
@@ -372,7 +372,7 @@ To streamline this you may also combine this with the concept of **User-Defined 
 
 ```ts
 function isString(a: unknown): a is string {
-  return typeof a === "string";
+  return typeof a === 'string';
 }
 ```
 
@@ -387,7 +387,7 @@ type Props1 = { foo: string };
 type Props2 = { bar: string };
 
 function MyComponent(props: Props1 | Props2) {
-  if ("foo" in props) {
+  if ('foo' in props) {
     // props.bar // error
     return <div>{props.foo}</div>;
   } else {
@@ -413,9 +413,9 @@ type OneOrAnother<T1, T2> =
 
 type Props = OneOrAnother<{ a: string; b: string }, {}>;
 
-const a: Props = { a: "a" }; // error
-const b: Props = { b: "b" }; // error
-const ab: Props = { a: "a", b: "b" }; // ok
+const a: Props = { a: 'a' }; // error
+const b: Props = { b: 'b' }; // error
+const ab: Props = { a: 'a', b: 'b' }; // ok
 ```
 
 Thanks [diegohaz](https://twitter.com/kentcdodds/status/1085655423611367426)
@@ -429,11 +429,11 @@ You want to allow `expanded` to be passed only if `truncate` is also passed, bec
 You can do this by function overloads:
 
 ```tsx
-import React from "react";
+import React from 'react';
 
 type CommonProps = {
   children: React.ReactNode;
-  as: "p" | "span" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  as: 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 };
 
 type NoTruncateProps = CommonProps & {
@@ -455,7 +455,7 @@ function Text(props: NoTruncateProps | TruncateProps) {
   if (isTruncateProps(props)) {
     const { children, as: Tag, truncate, expanded, ...otherProps } = props;
 
-    const classNames = truncate ? ".truncate" : "";
+    const classNames = truncate ? '.truncate' : '';
 
     return (
       <Tag className={classNames} aria-expanded={!!expanded} {...otherProps}>
@@ -470,7 +470,7 @@ function Text(props: NoTruncateProps | TruncateProps) {
 }
 
 Text.defaultProps = {
-  as: "span"
+  as: 'span'
 };
 ```
 
@@ -505,7 +505,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 // usage
 export const Checkbox = (
-  props: Props & Omit<React.HTMLProps<HTMLInputElement>, "label">
+  props: Props & Omit<React.HTMLProps<HTMLInputElement>, 'label'>
 ) => {
   const { label } = props;
   return (
@@ -525,7 +525,7 @@ As you can see from the Omit example above, you can write significant logic in y
 
 ## Extracting Prop Types of a Component
 
-_(Contributed by [@ferdaber](https://github.com/sw-yx/react-typescript-cheatsheet/issues/63))_
+_(Contributed by [@ferdaber](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/63))_
 
 There are a lot of places where you want to reuse some slices of props because of prop drilling,
 so you can either export the props type as part of the module or extract them (either way works).
@@ -533,7 +533,7 @@ so you can either export the props type as part of the module or extract them (e
 The advantage of extracting the prop types is that you won't need to export everything, and a refactor of the source of truth component will propagate to all consuming components.
 
 ```ts
-import { ComponentProps, JSXElementConstructor } from "react";
+import { ComponentProps, JSXElementConstructor } from 'react';
 
 // goes one step further and resolves with propTypes and defaultProps properties
 type ApparentComponentProps<
@@ -560,7 +560,7 @@ export function MyInnerComponent(props: {
 // my-consuming-component.tsx
 export function MyConsumingComponent() {
   // event and moreArgs are contextually typed along with the return value
-  const theHandler: Props<typeof MyInnerComponent>["onSomeEvent"] = (
+  const theHandler: Props<typeof MyInnerComponent>['onSomeEvent'] = (
     event,
     moreArgs
   ) => {};
@@ -584,8 +584,8 @@ class DateIsInFutureError extends RangeError {}
  */
 function parse(date: string) {
   if (!isValid(date))
-    throw new InvalidDateFormatError("not a valid date format");
-  if (isInFuture(date)) throw new DateIsInFutureError("date is in the future");
+    throw new InvalidDateFormatError('not a valid date format');
+  if (isInFuture(date)) throw new DateIsInFutureError('date is in the future');
   // ...
 }
 
@@ -593,9 +593,9 @@ try {
   // call parse(date) somewhere
 } catch (e) {
   if (e instanceof InvalidDateFormatError) {
-    console.error("invalid date format", e);
+    console.error('invalid date format', e);
   } else if (e instanceof DateIsInFutureError) {
-    console.warn("date is in future", e);
+    console.warn('date is in future', e);
   } else {
     throw e;
   }
@@ -609,24 +609,24 @@ function parse(
   date: string
 ): Date | InvalidDateFormatError | DateIsInFutureError {
   if (!isValid(date))
-    return new InvalidDateFormatError("not a valid date format");
-  if (isInFuture(date)) return new DateIsInFutureError("date is in the future");
+    return new InvalidDateFormatError('not a valid date format');
+  if (isInFuture(date)) return new DateIsInFutureError('date is in the future');
   // ...
 }
 
 // now consumer *has* to handle the errors
-let result = parse("mydate");
+let result = parse('mydate');
 if (result instanceof InvalidDateFormatError) {
-  console.error("invalid date format", result.message);
+  console.error('invalid date format', result.message);
 } else if (result instanceof DateIsInFutureError) {
-  console.warn("date is in future", result.message);
+  console.warn('date is in future', result.message);
 } else {
   /// use result safely
 }
 
 // alternately you can just handle all errors
 if (result instanceof Error) {
-  console.error("error", result);
+  console.error('error', result);
 } else {
   /// use result safely
 }
@@ -679,7 +679,7 @@ Sometimes DefinitelyTyped can get it wrong, or isn't quite addressing your use c
 
 # Section 2: Useful Patterns by TypeScript Version
 
-TypeScript Versions often introduce new ways to do things; this section helps current users of React + TypeScript upgrade TypeScript versions and explore patterns commonly used by TypeScript + React apps and libraries. This may have duplications with other sections; if you spot any discrepancies, [file an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new)!
+TypeScript Versions often introduce new ways to do things; this section helps current users of React + TypeScript upgrade TypeScript versions and explore patterns commonly used by TypeScript + React apps and libraries. This may have duplications with other sections; if you spot any discrepancies, [file an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new)!
 
 _TypeScript version guides before 2.9 are unwritten, please feel free to send a PR!_ Apart from official TS team communication we also recommend [Marius Schulz's blog for version notes](https://mariusschulz.com/).
 
@@ -696,8 +696,8 @@ export interface InputFormProps {
 
 export const InputForm = styledInput<InputFormProps>`
     color:
-        ${({ themeName }) => (themeName === "dark" ? "black" : "white")};
-    border-color: ${({ foo }) => (foo ? "red" : "black")};
+        ${({ themeName }) => (themeName === 'dark' ? 'black' : 'white')};
+    border-color: ${({ foo }) => (foo ? 'red' : 'black')};
 `;
 ```
 
@@ -730,8 +730,8 @@ function foo(...rest: string[]) {
   // ...
 }
 
-foo("hello"); // works
-foo("hello", "world"); // also works
+foo('hello'); // works
+foo('hello', 'world'); // also works
 ```
 
 2. Support for `propTypes` and `static defaultProps` in JSX using `LibraryManagedAttributes`:
@@ -746,7 +746,7 @@ export class Greet extends React.Component<Props> {
     const { name } = this.props;
     return <div>Hello ${name.toUpperCase()}!</div>;
   }
-  static defaultProps = { name: "world" };
+  static defaultProps = { name: 'world' };
 }
 
 // Type-checks! No type assertions needed!
@@ -781,7 +781,7 @@ let service2: IDataService2;
 const response2 = service2.getData();
 // response2.a.b.c.d; // COMPILE TIME ERROR if you do this
 
-if (typeof response === "string") {
+if (typeof response === 'string') {
   console.log(response.toUpperCase()); // `response` now has type 'string'
 }
 ```
@@ -849,7 +849,7 @@ Attaching properties to functions like this "just works" now:
 export const FooComponent = ({ name }) => <div>Hello! I am {name}</div>;
 
 FooComponent.defaultProps = {
-  name: "swyx"
+  name: 'swyx'
 };
 ```
 
@@ -935,14 +935,14 @@ export class MyComponent extends React.Component<IMyComponentProps, {}> {
 }
 ```
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Commenting Components
 
 Typescript uses [TSDoc](https://github.com/Microsoft/tsdoc), a variant of JSDoc for Typescript. This is very handy for writing component libraries and having useful descriptions pop up in autocomplete and other tooling (like the [Docz PropsTable](https://www.docz.site/documentation/components-api#propstable)). The main thing to remember is to use `/** YOUR_COMMENT_HERE */` syntax in the line just above whatever you're annotating.
 
 ```tsx
-import React from "react";
+import React from 'react';
 
 interface MyProps {
   /** Description of prop "label".
@@ -954,12 +954,12 @@ interface MyProps {
 /**
  * General component description in JSDoc format. Markdown is *supported*.
  */
-export default function MyComponent({ label = "foobar" }: MyProps) {
+export default function MyComponent({ label = 'foobar' }: MyProps) {
   return <div>Hello world {label}</div>;
 }
 ```
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Design System Development
 
@@ -967,7 +967,7 @@ I do like [Docz](https://docz.site/) which takes basically [1 line of config](ht
 
 For developing with Storybook, read the docs I wrote over here: <https://storybook.js.org/configurations/typescript-config/>. This includes automatic proptype documentation generation, which is awesome :)
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Migrating From Flow
 
@@ -986,7 +986,7 @@ Useful libraries:
 
 If you have specific advice in this area, please file a PR!
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Prettier
 
@@ -1027,7 +1027,7 @@ This is set up for you in [tsdx](https://github.com/palmerhq/tsdx/pull/45/files)
 
 ## Linting
 
-> ⚠️Note that [TSLint is now in maintenance and you should try to use ESLint instead](https://medium.com/palantir/tslint-in-2019-1a144c2317a9). If you are interested in TSLint tips, please check this PR from [@azdanov](https://github.com/sw-yx/react-typescript-cheatsheet/pull/14). The rest of this section just focuses on ESLint.
+> ⚠️Note that [TSLint is now in maintenance and you should try to use ESLint instead](https://medium.com/palantir/tslint-in-2019-1a144c2317a9). If you are interested in TSLint tips, please check this PR from [@azdanov](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/14). The rest of this section just focuses on ESLint.
 
 > ⚠️This is an evolving topic. `typescript-eslint-parser` is no longer maintained and [work has recently begun on `typescript-eslint` in the ESLint community](https://eslint.org/blog/2019/01/future-typescript-eslint) to bring ESLint up to full parity and interop with TSLint.
 
@@ -1137,7 +1137,7 @@ So create a `.d.ts` file anywhere in your project with the module definition:
 
 ```ts
 // de-indent.d.ts
-declare module "de-indent" {
+declare module 'de-indent' {
   function deindent(): void;
   export = deindent; // default export
 }
@@ -1147,7 +1147,7 @@ declare module "de-indent" {
 
 <summary>Further Discussion</summary>
 
-Any other tips? Please contribute on this topic! [We have an ongoing issue here with some references](https://github.com/sw-yx/react-typescript-cheatsheet/issues/8). We have more discussion and examples [in our issue here](https://github.com/sw-yx/react-typescript-cheatsheet/issues/12).
+Any other tips? Please contribute on this topic! [We have an ongoing issue here with some references](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/8). We have more discussion and examples [in our issue here](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/12).
 
 </details>
 
@@ -1185,7 +1185,7 @@ Not Commonly Used but Good to know
 - `ComponentPropsWithoutRef` - props of a component without its `ref` prop
 - all methods: `createElement`, `cloneElement`, ... are all public and reflect the React runtime API
 
-[@Ferdaber's note](https://github.com/sw-yx/react-typescript-cheatsheet/pull/69): I discourage the use of most `...Element` types because of how black-boxy `JSX.Element` is. You should almost always assume that anything produced by `React.createElement` is the base type `React.ReactElement`.
+[@Ferdaber's note](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/69): I discourage the use of most `...Element` types because of how black-boxy `JSX.Element` is. You should almost always assume that anything produced by `React.createElement` is the base type `React.ReactElement`.
 
 **Namespace: JSX**
 
@@ -1216,4 +1216,4 @@ To be written
 
 # My question isn't answered here!
 
-- [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+- [File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).

--- a/HOC.md
+++ b/HOC.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://github.com/sw-yx/react-typescript-cheatsheet/issues/81">
+<a href="https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/81">
   <img
     height="90"
     width="90"
@@ -12,13 +12,13 @@
 
 <p>Cheatsheets for experienced React developers getting started with TypeScript</p>
 
-[**Basic**](https://github.com/sw-yx/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
-[**Advanced**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
-[**Migrating**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
-[**HOC**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/HOC.md) |
+[**Basic**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
+[**Advanced**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
+[**Migrating**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
+[**HOC**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/HOC.md) |
 [中文翻译](https://github.com/fi3ework/blog/tree/master/react-typescript-cheatsheet-cn) |
-[Contribute!](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
-[Ask!](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new/choose)
+[Contribute!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
+[Ask!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new/choose)
 
 </div>
 
@@ -67,15 +67,15 @@ const TextBlock = Comment;
 type CommentType = { text: string; id: number };
 const comments: CommentType[] = [
   {
-    text: "comment1",
+    text: 'comment1',
     id: 1
   },
   {
-    text: "comment2",
+    text: 'comment2',
     id: 2
   }
 ];
-const blog = "blogpost";
+const blog = 'blogpost';
 
 /** mock data source */
 const DataSource = {
@@ -142,12 +142,12 @@ export function withSubscription<T, P extends WithDataProps<T>, C>(
   // props is Readonly because it's readonly inside of the class
   selectData: (
     dataSource: typeof DataSource,
-    props: Readonly<JSX.LibraryManagedAttributes<C, Omit<P, "data">>>
+    props: Readonly<JSX.LibraryManagedAttributes<C, Omit<P, 'data'>>>
   ) => T
 ) {
   // the magic is here: JSX.LibraryManagedAttributes will take the type of WrapedComponent and resolve its default props
   // against the props of WithData, which is just the original P type with 'data' removed from its requirements
-  type Props = JSX.LibraryManagedAttributes<C, Omit<P, "data">>;
+  type Props = JSX.LibraryManagedAttributes<C, Omit<P, 'data'>>;
   type State = {
     data: T;
   };
@@ -187,7 +187,7 @@ export const CommentListWithSubscription = withSubscription(
 
 export const BlogPostWithSubscription = withSubscription(
   BlogPost,
-  (DataSource: DataType, props: Omit<BlogPostProps, "data">) =>
+  (DataSource: DataType, props: Omit<BlogPostProps, 'data'>) =>
     DataSource.getBlogPost(props.id)
 );
 ```
@@ -202,8 +202,8 @@ function logProps<T>(WrappedComponent: React.ComponentType<T>) {
     componentWillReceiveProps(
       nextProps: React.ComponentProps<typeof WrappedComponent>
     ) {
-      console.log("Current props: ", this.props);
-      console.log("Next props: ", nextProps);
+      console.log('Current props: ', this.props);
+      console.log('Next props: ', nextProps);
     }
     render() {
       // Wraps the input component in a container, without mutating it. Good!
@@ -239,11 +239,11 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type CommentType = { text: string; id: number };
 const comments: CommentType[] = [
   {
-    text: "comment1",
+    text: 'comment1',
     id: 1
   },
   {
-    text: "comment2",
+    text: 'comment2',
     id: 2
   }
 ];
@@ -284,7 +284,7 @@ function connect(mapStateToProps: Function, mapDispatchToProps: Function) {
   return function<T, P extends WithSubscriptionProps<T>, C>(
     WrappedComponent: React.ComponentType<T>
   ) {
-    type Props = JSX.LibraryManagedAttributes<C, Omit<P, "data">>;
+    type Props = JSX.LibraryManagedAttributes<C, Omit<P, 'data'>>;
     // Creating the inner component. The calculated Props type here is the where the magic happens.
     return class ComponentWithTheme extends React.Component<Props> {
       public render() {
@@ -327,7 +327,7 @@ function withSubscription<
 }
 
 function getDisplayName<T>(WrappedComponent: React.ComponentType<T>) {
-  return WrappedComponent.displayName || WrappedComponent.name || "Component";
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 ```
 
@@ -356,7 +356,7 @@ function Dog({name, owner}: DogProps) {
 And we have a `withOwner` HOC that injects the `owner`:
 
 ```tsx
-const OwnedDog = withOwner("swyx")(Dog);
+const OwnedDog = withOwner('swyx')(Dog);
 ```
 
 We want to type `withOwner` such that it will pass through the types of any component like `Dog`, into the type of `OwnedDog`, minus the `owner` property it injects:
@@ -377,13 +377,13 @@ type CatProps = {
 function Cat({ lives, owner }: CatProps) {
   return (
     <div>
-      {" "}
+      {' '}
       Meow: {lives}, Owner: {owner}
     </div>
   );
 }
 
-const OwnedCat = withOwner("swyx")(Cat);
+const OwnedCat = withOwner('swyx')(Cat);
 
 <Cat lives={9} owner="swyx" />; // this should be fine
 <OwnedCat lives={9} owner="swyx" />; // this should have a typeError
@@ -404,7 +404,7 @@ function withOwner(owner: string) {
   return function<T extends { owner: string }>(
     Component: React.ComponentType<T>
   ) {
-    return function(props: Omit<T, "owner">): React.ReactNode {
+    return function(props: Omit<T, 'owner'>): React.ReactNode {
       return <Component owner={owner} {...props} />;
     };
   };

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://github.com/sw-yx/react-typescript-cheatsheet/issues/81">
+<a href="https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/81">
   <img
     height="90"
     width="90"
@@ -12,13 +12,13 @@
 
 <p>Cheatsheets for experienced React developers getting started with TypeScript</p>
 
-[**Basic**](https://github.com/sw-yx/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
-[**Advanced**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
-[**Migrating**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
-[**HOC**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/HOC.md) |
+[**Basic**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
+[**Advanced**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
+[**Migrating**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
+[**HOC**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/HOC.md) |
 [中文翻译](https://github.com/fi3ework/blog/tree/master/react-typescript-cheatsheet-cn) |
-[Contribute!](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
-[Ask!](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new/choose)
+[Contribute!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
+[Ask!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new/choose)
 
 </div>
 
@@ -46,7 +46,7 @@ Read [TypeScript's official Guide for migrating from JS](https://www.typescriptl
   - use the loosest, bare minimum settings to start with
 - Level 2: Strict TypeScript
   - use Microsoft's [`dts-gen`](https://github.com/Microsoft/dts-gen) to generate `.d.ts` files for your untyped files. [This SO answer](https://stackoverflow.com/questions/12687779/how-do-you-produce-a-d-ts-typings-definition-file-from-an-existing-javascript) has more on the topic.
-  - use `declare` keyword for ambient declarations - see [declaration merging](https://github.com/sw-yx/react-typescript-cheatsheet#troubleshooting-handbook-bugs-in-official-typings) to patch library declarations inline
+  - use `declare` keyword for ambient declarations - see [declaration merging](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#troubleshooting-handbook-bugs-in-official-typings) to patch library declarations inline
 
 Misc tips/approaches successful companies have taken
 
@@ -193,7 +193,7 @@ Old content that is possibly out of date
 
 ## From Flow
 
-- Try flow2ts: `npx flow2ts` - doesn't work 100% but saves some time ([see this and other tips from @braposo](https://github.com/sw-yx/react-typescript-cheatsheet/pull/79#issuecomment-458227322) at TravelRepublic)
+- Try flow2ts: `npx flow2ts` - doesn't work 100% but saves some time ([see this and other tips from @braposo](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/79#issuecomment-458227322) at TravelRepublic)
 - [Incremental Migration to TypeScript on a Flowtype codebase][entria] at Entria
 - [Jest's migration (PR)](https://github.com/facebook/jest/pull/7554#issuecomment-454358729)
 - [Expo's migration (issue)](https://github.com/expo/expo/issues/2164)
@@ -218,10 +218,10 @@ Old content that is possibly out of date
 
 ## Links
 
-[hootsuite]: https://medium.com/hootsuite-engineering/thoughts-on-migrating-to-typescript-5e1a04288202 "Thoughts on migrating to TypeScript"
-[clayallsop]: https://medium.com/@clayallsopp/incrementally-migrating-javascript-to-typescript-565020e49c88 "Incrementally Migrating JavaScript to TypeScript"
-[pleo]: https://medium.com/pleo/migrating-a-babel-project-to-typescript-af6cd0b451f4 "Migrating a Babel project to TypeScript"
-[mstsreactconversionguide]: https://github.com/Microsoft/TypeScript-React-Conversion-Guide "TypeScript React Conversion Guide"
-[entria]: https://medium.com/entria/incremental-migration-to-typescript-on-a-flowtype-codebase-515f6490d92d "Incremental Migration to TypeScript on a Flowtype codebase"
-[coherentlabs]: https://hashnode.com/post/how-we-migrated-a-200k-loc-project-to-typescript-and-survived-to-tell-the-story-ciyzhikcc0001y253w00n11yb "How we migrated a 200K+ LOC project to TypeScript and survived to tell the story"
-[tiny]: https://go.tiny.cloud/blog/benefits-of-gradual-strong-typing-in-javascript/ "Benefits of gradual strong typing in JavaScript"
+[hootsuite]: https://medium.com/hootsuite-engineering/thoughts-on-migrating-to-typescript-5e1a04288202 'Thoughts on migrating to TypeScript'
+[clayallsop]: https://medium.com/@clayallsopp/incrementally-migrating-javascript-to-typescript-565020e49c88 'Incrementally Migrating JavaScript to TypeScript'
+[pleo]: https://medium.com/pleo/migrating-a-babel-project-to-typescript-af6cd0b451f4 'Migrating a Babel project to TypeScript'
+[mstsreactconversionguide]: https://github.com/Microsoft/TypeScript-React-Conversion-Guide 'TypeScript React Conversion Guide'
+[entria]: https://medium.com/entria/incremental-migration-to-typescript-on-a-flowtype-codebase-515f6490d92d 'Incremental Migration to TypeScript on a Flowtype codebase'
+[coherentlabs]: https://hashnode.com/post/how-we-migrated-a-200k-loc-project-to-typescript-and-survived-to-tell-the-story-ciyzhikcc0001y253w00n11yb 'How we migrated a 200K+ LOC project to TypeScript and survived to tell the story'
+[tiny]: https://go.tiny.cloud/blog/benefits-of-gradual-strong-typing-in-javascript/ 'Benefits of gradual strong typing in JavaScript'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1>React+TypeScript Cheatsheets</h1>
 
-<a href="https://github.com/sw-yx/react-typescript-cheatsheet/issues/81">
+<a href="https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/81">
   <img
     height="90"
     width="90"
@@ -13,13 +13,13 @@
 
 <p>Cheatsheets for experienced React developers getting started with TypeScript</p>
 
-[**Basic**](https://github.com/sw-yx/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
-[**Advanced**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
-[**Migrating**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
-[**HOC**](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/HOC.md) |
+[**Basic**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#basic-cheatsheet-table-of-contents) |
+[**Advanced**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/ADVANCED.md) |
+[**Migrating**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/MIGRATING.md) |
+[**HOC**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/HOC.md) |
 [中文翻译](https://github.com/fi3ework/blog/tree/master/react-typescript-cheatsheet-cn) |
-[Contribute!](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
-[Ask!](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new/choose)
+[Contribute!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |
+[Ask!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new/choose)
 
 </div>
 
@@ -27,7 +27,7 @@
 
 <div align="center">
 
-:wave: This repo is maintained by [@swyx](https://twitter.com/swyx), [@ferdaber](https://twitter.com/ferdaber), [@eps1lon](https://twitter.com/sebsilbermann) and [@IslamAttrash](https://twitter.com/IslamAttrash), we're so happy you want to try out TypeScript with React! If you see anything wrong or missing, please [file an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new/choose)! :+1:
+:wave: This repo is maintained by [@swyx](https://twitter.com/swyx), [@ferdaber](https://twitter.com/ferdaber), [@eps1lon](https://twitter.com/sebsilbermann) and [@IslamAttrash](https://twitter.com/IslamAttrash), we're so happy you want to try out TypeScript with React! If you see anything wrong or missing, please [file an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new/choose)! :+1:
 
 </div>
 
@@ -119,7 +119,7 @@ This guide will always assume you are starting with the latest TypeScript versio
 2. [Basarat's guide](https://github.com/basarat/typescript-react/tree/master/01%20bootstrap) for **manual setup** of React + TypeScript + Webpack + Babel
 
 - In particular, make sure that you have `@types/react` and `@types/react-dom` installed ([Read more about the DefinitelyTyped project if you are unfamiliar](https://definitelytyped.org/))
-- There are also many React + TypeScript boilerplates, please see [our Resources list below](https://github.com/sw-yx/react-typescript-cheatsheet#recommended-react--typescript-codebases-to-learn-from).
+- There are also many React + TypeScript boilerplates, please see [our Resources list below](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#recommended-react--typescript-codebases-to-learn-from).
 
 ## Import React
 
@@ -141,7 +141,7 @@ import ReactDOM from "react-dom";
 
 Why `allowSyntheticDefaultImports` over `esModuleInterop`? [Daniel Rosenwasser](https://twitter.com/drosenwasser/status/1003097042653073408) has said that it's better for webpack/parcel. For more discussion check out <https://github.com/wmonk/create-react-app-typescript/issues/214>
 
-Please PR or [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new) with your suggestions!
+Please PR or [File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new) with your suggestions!
 
 </details>
 
@@ -170,7 +170,7 @@ const App: React.FC<{ message: string }> = ({ message }) => (
 
 Some differences from the "normal function" version:
 
-- It provides typechecking and autocomplete for static properties like `displayName`, `propTypes`, and `defaultProps` - **However**, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/sw-yx/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
+- It provides typechecking and autocomplete for static properties like `displayName`, `propTypes`, and `defaultProps` - **However**, there are currently known issues using `defaultProps` with `React.FunctionComponent`. See [this issue for details](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/87) - scroll down to our `defaultProps` section for typing recommendations there.
 
 - It provides an implicit definition of `children` (see below) - however there are some issues with the implicit `children` type (e.g. [DefinitelyTyped#33006](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33006)), and it might considered better style to be explicit about components that consume `children`, anyway.
 
@@ -217,7 +217,7 @@ Unfortunately just annotating the function type will not help so if you really n
 const MyArrayComponent = () => (Array(5).fill(<div />) as any) as JSX.Element;
 ```
 
-[See commentary by @ferdaber here](https://github.com/sw-yx/react-typescript-cheatsheet/issues/57).
+[See commentary by @ferdaber here](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/57).
 
 </details>
 
@@ -402,7 +402,7 @@ Example React Hooks + TypeScript Libraries:
 - https://github.com/palmerhq/the-platform
 - https://github.com/sw-yx/hooks
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Class Components
 
@@ -440,7 +440,7 @@ It isn't strictly necessary to annotate the `state` class property, but it allow
 
 This is because they work in two different ways, the 2nd generic type parameter will allow `this.setState()` to work correctly, because that method comes from the base class, but initializing `state` inside the component overrides the base implementation so you have to make sure that you tell the compiler that you're not actually doing anything different.
 
-[See commentary by @ferdaber here](https://github.com/sw-yx/react-typescript-cheatsheet/issues/57).
+[See commentary by @ferdaber here](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/57).
 
 </details>
 
@@ -503,11 +503,11 @@ class App extends React.Component<{
 }
 ```
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Typing defaultProps
 
-For Typescript 3.0+, type inference [should work](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html), although [some edge cases are still problematic](https://github.com/sw-yx/react-typescript-cheatsheet/issues/61). Just type your props like normal, except don't use `React.FC`.
+For Typescript 3.0+, type inference [should work](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html), although [some edge cases are still problematic](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/61). Just type your props like normal, except don't use `React.FC`.
 
 ```tsx
 // ////////////////
@@ -524,7 +524,7 @@ const Greet = (props: Props) => {
 Greet.defaultProps = defaultProps;
 ```
 
-For **Class components**, there are [a couple ways to do it](https://github.com/sw-yx/react-typescript-cheatsheet/pull/103#issuecomment-481061483)(including using the `Pick` utility type) but the recommendation is to "reverse" the props definition:
+For **Class components**, there are [a couple ways to do it](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/103#issuecomment-481061483)(including using the `Pick` utility type) but the recommendation is to "reverse" the props definition:
 
 ```tsx
 type GreetProps = typeof Greet.defaultProps & {
@@ -549,7 +549,7 @@ You can check the discussions here:
 
 - https://medium.com/@martin_hotell/10-typescript-pro-tips-patterns-with-or-without-react-5799488d6680
 - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30695
-- https://github.com/sw-yx/react-typescript-cheatsheet/issues/87
+- https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/87
 
 This is just the current state and may be fixed in future.
 
@@ -589,11 +589,11 @@ export class MyComponent extends React.Component<IMyComponentProps> {
 
 The problem with this approach is it causes complex issues with the type inference working with `JSX.LibraryManagedAttributes`. Basically it causes the compiler to think that when creating a JSX expression with that component, that all of its props are optional.
 
-[See commentary by @ferdaber here](https://github.com/sw-yx/react-typescript-cheatsheet/issues/57).
+[See commentary by @ferdaber here](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/57).
 
 </details>
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Types or Interfaces?
 
@@ -615,7 +615,7 @@ It's a nuanced topic, don't get too hung up on it. Here's a handy graphic:
 
 </details>
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Basic Prop Types Examples
 
@@ -675,7 +675,7 @@ export declare interface AppProps {
 <details>
  <summary><b>JSX.Element vs React.ReactNode?</b></summary>
 
-Quote [@ferdaber](https://github.com/sw-yx/react-typescript-cheatsheet/issues/57): A more technical explanation is that a valid React node is not the same thing as what is returned by `React.createElement`. Regardless of what a component ends up rendering, `React.createElement` always returns an object, which is the `JSX.Element` interface, but `React.ReactNode` is the set of all possible return values of a component.
+Quote [@ferdaber](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/57): A more technical explanation is that a valid React node is not the same thing as what is returned by `React.createElement`. Regardless of what a component ends up rendering, `React.createElement` always returns an object, which is the `JSX.Element` interface, but `React.ReactNode` is the set of all possible return values of a component.
 
 - `JSX.Element` -> Return value of `React.createElement`
 - `React.ReactNode` -> Return value of a component
@@ -683,7 +683,7 @@ Quote [@ferdaber](https://github.com/sw-yx/react-typescript-cheatsheet/issues/57
 
 [More discussion: Where ReactNode does not overlap with JSX.Element](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/129)
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Forms and Events
 
@@ -740,7 +740,7 @@ Instead of typing the arguments and return values with `React.FormEvent<>` and `
 
 <summary><b>Why two ways to do the same thing?</b></summary>
 
-The first method uses an inferred method signature `(e: React.FormEvent<HTMLInputElement>): void` and the second method enforces a type of the delegate provided by `@types/react`. So `React.ChangeEventHandler<>` is simply a "blessed" typing by `@types/react`, whereas you can think of the inferred method as more... _artisanally hand-rolled_. Either way it's a good pattern to know. [See our Github PR for more](https://github.com/sw-yx/react-typescript-cheatsheet/pull/24).
+The first method uses an inferred method signature `(e: React.FormEvent<HTMLInputElement>): void` and the second method enforces a type of the delegate provided by `@types/react`. So `React.ChangeEventHandler<>` is simply a "blessed" typing by `@types/react`, whereas you can think of the inferred method as more... _artisanally hand-rolled_. Either way it's a good pattern to know. [See our Github PR for more](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/24).
 
 </details>
 
@@ -861,7 +861,7 @@ A [useReducer-based version](https://gist.github.com/sw-yx/f18fe6dd4c43fddb3a497
 
 <summary><b>Mutable Context Using a Class component wrapper</b></summary>
 
-_Contributed by: [@jpavon](https://github.com/sw-yx/react-typescript-cheatsheet/pull/13)_
+_Contributed by: [@jpavon](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/13)_
 
 ```tsx
 interface ProviderState {
@@ -906,11 +906,11 @@ const Consumer = Context.Consumer;
 
 </details>
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## forwardRef/createRef
 
-Check the [Hooks section](https://github.com/sw-yx/react-typescript-cheatsheet/blob/master/README.md) for `useRef`.
+Check the [Hooks section](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/README.md) for `useRef`.
 
 `createRef`:
 
@@ -939,7 +939,7 @@ If you are grabbing the props of a component that forwards refs, use [`Component
 
 More info: https://medium.com/@martin_hotell/react-refs-with-typescript-a32d56c4d315
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Portals
 
@@ -978,13 +978,13 @@ This example is based on the [Event Bubbling Through Portal](https://reactjs.org
 
 _Not written yet._
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Concurrent React/React Suspense
 
 _Not written yet._ watch <https://github.com/sw-yx/fresh-async-react> for more on React Suspense and Time Slicing.
 
-[Something to add? File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+[Something to add? File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 # Basic Troubleshooting Handbook: Types
 
@@ -1063,7 +1063,7 @@ class MyComponent extends React.Component<{
 
 You can also use a `!` character to assert that something is not undefined, but this is not encouraged.
 
-_Something to add? [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new) with your suggestions!_
+_Something to add? [File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new) with your suggestions!_
 
 ## Enum Types
 
@@ -1373,7 +1373,7 @@ so on and so forth. there are any number of things you can disable, usually you 
 
 <summary>Explanation</summary>
 
-This is not yet written. Please PR or [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new) with your suggestions!
+This is not yet written. Please PR or [File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new) with your suggestions!
 
 </details>
 
@@ -1500,7 +1500,7 @@ React Boilerplates:
 - [webpack config tool](https://webpack.jakoblind.no/) is a visual tool for creating webpack projects with React and TypeScript
 - <https://github.com/innFactory/create-react-app-material-typescript-redux> ready to go template with [Material-UI](https://material-ui.com/), routing and Redux
 
-React Native Boilerplates: _contributed by [@spoeck](https://github.com/sw-yx/react-typescript-cheatsheet/pull/20)_
+React Native Boilerplates: _contributed by [@spoeck](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/20)_
 
 - https://github.com/GeekyAnts/react-native-seed
 - https://github.com/lopezjurip/ReactNativeTS
@@ -1534,7 +1534,7 @@ React Native Boilerplates: _contributed by [@spoeck](https://github.com/sw-yx/re
   - [Lyft's React-To-Typescript conversion CLI](https://github.com/lyft/react-javascript-to-typescript-transform)
   - [Gustav Wengel's blogpost - converting a React codebase to Typescript](http://www.gustavwengel.dk/converting-typescript-to-javascript-part-1)
   - [Microsoft React Typescript conversion guide](https://github.com/Microsoft/TypeScript-React-Conversion-Guide#typescript-react-conversion-guide)
-- [You?](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+- [You?](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 # Recommended React + TypeScript talks
 
@@ -1554,7 +1554,7 @@ It is worth mentioning some resources to help you get started:
 # My question isn't answered here!
 
 - Check out [the Advanced Cheatsheet](/ADVANCED.md)
-- [File an issue](https://github.com/sw-yx/react-typescript-cheatsheet/issues/new).
+- [File an issue](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/new).
 
 ## Contributors
 


### PR DESCRIPTION
Hey, first of all, thanks for this project! Really cool initiative here. 🙌

Just fixes the link to point at the repo under the new organization, which prevents a 301 (and new page loads, if they are just anchor links).

During this change, Prettier formatted according to [the existing settings in `package.json`](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/9207c083e1e9dd33de99147e807187ce20f0fad5/package.json#L24-L26). If that's not acceptable, I can revert these changes (maybe we should change the configuration too? maybe using [Overrides](https://prettier.io/docs/en/configuration.html#configuration-overrides)?).