### PR TITLE
Link 'basic cheetsheet' directly to the basic TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## All React + TypeScript Cheatsheets
 
-- **The Basic Cheatsheet** ([`/README.md`](/README.md)) is focused on helping React devs just start using TS in React **apps**
+- **The Basic Cheatsheet** ([`/README.md`](/README.md#basic-cheatsheet-table-of-contents)) is focused on helping React devs just start using TS in React **apps**
   - focus on opinionated best practices, copy+pastable examples
   - explains some basic TS types usage and setup along the way
   - answers the most Frequently Asked Questions


### PR DESCRIPTION
Previously it just linked to README.md, which you're already viewing, so effectively jumped back to the top of the file, which is a bit confusing.

It now jumps to the TOC at the start of the cheetsheet itself.

This is also nicely consistent with the existing 'Basic | Advanced | Migrating | HOC ...' header which already does the same thing.