### PR TITLE
README: add last 2 chapter in the Toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@
 - [Editor Tooling and Integration](#editor-tooling-and-integration)
 - [Other React + TypeScript resources](#other-react--typescript-resources)
 - [Time to Really Learn TypeScript](#time-to-really-learn-typescript)
+- [Example App](#example-app)
+- [My question isn't answered here!](#my-question-isnt-answered-here)
   </details>
 
 # Section 1: Setup


### PR DESCRIPTION
hello! 
I still refer this doc and figure outing something new!( especially `Forms and Events`)

# Overview

I noticed about not exist chapter in the Toc,
So I added last 2 chapters link in the Toc.

Links behavior was tested on the my forked repo.

![GVnq8xd4ma](https://user-images.githubusercontent.com/5501268/64692100-3c824580-d4cf-11e9-8d18-ca3596f58751.gif)

Thank you so much reading 😀