### PR TITLE
fix: remove unnecessary alwaysStrict flag from tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1534,7 +1534,6 @@ You can find [all the Compiler options in the Typescript docs](https://www.types
     "declaration": true,
     "rootDir": "src",
     "strict": true,
-    "alwaysStrict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
According to the [Compiler Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) in the Handbook, setting `"strict": true` enables `--alwaysStrict` so no need to include it.

This PR removes `"alwaysStrict": true` from the recommended `tsconfig.json`. 

<img width="991" alt="image" src="https://user-images.githubusercontent.com/3806031/70393336-00636180-19a6-11ea-8dc7-ce04fe09dae6.png">
