### PR TITLE
docs(advanced) Correct the section about discrinated types

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -512,23 +512,6 @@ You may also want to use Discriminated Unions, please check out [Expressive Reac
 Here is a brief intuition for **Discriminated Union Types**:
 
 ```ts
-type UserTextEvent = { value: string; target: HTMLInputElement };
-type UserMouseEvent = { value: [number, number]; target: HTMLElement };
-type UserEvent = UserTextEvent | UserMouseEvent;
-function handle(event: UserEvent) {
-  if (typeof event.value === "string") {
-    event.value; // string
-    event.target; // HTMLInputElement | HTMLElement (!!!!)
-    return;
-  }
-  event.value; // [number, number]
-  event.target; // HTMLInputElement | HTMLElement (!!!!)
-}
-```
-
-Even though we have narrowed based on `event.value`, the logic doesn't filter up and sideways to `event.target`. This is because a union type `UserTextEvent | UserMouseEvent` could be BOTH at once. So TypeScript needs a better hint. The solution is to use a literal type to tag each case of your union type:
-
-```ts
 type UserTextEvent = {
   type: "TextEvent";
   value: string;
@@ -550,6 +533,30 @@ function handle(event: UserEvent) {
   event.target; // HTMLElement
 }
 ```
+
+<details>
+  <summary>
+  Take care: TypeScript does not narrow the type of a Discriminated Union on the basis of typeof checks. The type guard has to be on the value of a key and not it's type.
+  </summary>
+
+```ts
+type UserTextEvent = { value: string; target: HTMLInputElement };
+type UserMouseEvent = { value: [number, number]; target: HTMLElement };
+type UserEvent = UserTextEvent | UserMouseEvent;
+function handle(event: UserEvent) {
+  if (typeof event.value === "string") {
+    event.value; // string
+    event.target; // HTMLInputElement | HTMLElement (!!!!)
+    return;
+  }
+  event.value; // [number, number]
+  event.target; // HTMLInputElement | HTMLElement (!!!!)
+}
+```
+
+The above example does not work as we are not checking the value of `event.value` but only it's type. Read more about it [microsoft/TypeScript#30506 (comment)](https://github.com/microsoft/TypeScript/issues/30506#issuecomment-474858198)
+
+</details>
 
 To streamline this you may also combine this with the concept of **User-Defined Type Guards**:
 


### PR DESCRIPTION
This is just finishing the work in https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/pull/183

I think this is important to mention that discriminated unions work only on value checks and not on `typeof` checks.