### PR TITLE
chore: Bump prettier to 2.0

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -226,7 +226,7 @@ You can then use the generic components and get nice type safety through type in
 ReactDOM.render(
   <List
     items={["a", "b"]} // type of 'string' inferred
-    renderItem={item => (
+    renderItem={(item) => (
       <li key={item}>
         {/* Error: Property 'toPrecision' does not exist on type 'string'. */}
         {item.toPrecision(3)}
@@ -243,7 +243,7 @@ As of [TS 2.9](#typescript-29), you can also supply the type parameter in your J
 ReactDOM.render(
   <List<number>
     items={["a", "b"]} // Error: Type 'string' is not assignable to type 'number'.
-    renderItem={item => <li key={item}>{item.toPrecision(3)}</li>}
+    renderItem={(item) => <li key={item}>{item.toPrecision(3)}</li>}
   />,
   document.body
 );
@@ -288,7 +288,7 @@ interface State<T> {
 class List<T> extends React.PureComponent<Props<T>, State<T>> {
   // You can use type T inside List class.
   state: Readonly<State<T>> = {
-    items: []
+    items: [],
   };
   render() {
     const { items, renderItem } = this.props;
@@ -352,7 +352,7 @@ Type '{ children: string; item: string; renderItem: (item: string) => string; }'
 */
 
 const wrapper = (
-  <Wrapper item="test" renderItem={item => item}>
+  <Wrapper item="test" renderItem={(item) => item}>
     {test}
   </Wrapper>
 );
@@ -481,7 +481,7 @@ interface Button {
   as: React.ComponentClass | "a";
 }
 
-const Button: React.FunctionComgetOrElseponent<Button> = props => {
+const Button: React.FunctionComgetOrElseponent<Button> = (props) => {
   const { as: Component, children, ...rest } = props;
   return (
     <Component className="button" {...rest}>
@@ -490,11 +490,11 @@ const Button: React.FunctionComgetOrElseponent<Button> = props => {
   );
 };
 
-const AnchorButton: React.FunctionComponent<AnchorProps> = props => (
+const AnchorButton: React.FunctionComponent<AnchorProps> = (props) => (
   <Button as="a" {...props} />
 );
 
-const LinkButton: React.FunctionComponent<RouterLinkProps> = props => (
+const LinkButton: React.FunctionComponent<RouterLinkProps> = (props) => (
   <Button as={NavLink} {...props} />
 );
 
@@ -853,14 +853,14 @@ class None implements Option<never> {
 
 // now you can use it like:
 let result = Option(6) // Some<number>
-  .flatMap(n => Option(n * 3)) // Some<number>
+  .flatMap((n) => Option(n * 3)) // Some<number>
   .flatMap((n = new None())) // None
   .getOrElse(7);
 
 // or:
 let result = ask() // Option<string>
   .flatMap(parse) // Option<Date>
-  .flatMap(d => new Some(d.toISOString())) // Option<string>
+  .flatMap((d) => new Some(d.toISOString())) // Option<string>
   .getOrElse("error parsing string");
 ```
 
@@ -908,7 +908,7 @@ Helps with typing/using generic components:
 
 // usage
 <Formik<Values>
-  render={props => {
+  render={(props) => {
     /* your code here ... */
   }}
 />;
@@ -1046,7 +1046,7 @@ Attaching properties to functions like this "just works" now:
 export const FooComponent = ({ name }) => <div>Hello! I am {name}</div>;
 
 FooComponent.defaultProps = {
-  name: "swyx"
+  name: "swyx",
 };
 ```
 
@@ -1269,7 +1269,7 @@ interface IMyComponentProps {
 export class MyComponent extends React.Component<IMyComponentProps, {}> {
   static propTypes = {
     autoHeight: PropTypes.bool,
-    secondProp: PropTypes.number.isRequired
+    secondProp: PropTypes.number.isRequired,
   };
 }
 ```

--- a/HOC.md
+++ b/HOC.md
@@ -166,12 +166,12 @@ type CommentType = { text: string; id: number };
 const comments: CommentType[] = [
   {
     text: "comment1",
-    id: 1
+    id: 1,
   },
   {
     text: "comment2",
-    id: 2
-  }
+    id: 2,
+  },
 ];
 const blog = "blogpost";
 
@@ -188,7 +188,7 @@ const DataSource = {
   },
   getBlogPost(id: number) {
     return blog;
-  }
+  },
 };
 /** type aliases just to deduplicate */
 type DataType = typeof DataSource;
@@ -256,7 +256,7 @@ export function withSubscription<T, P extends WithDataProps<T>, C>(
       super(props);
       this.handleChange = this.handleChange.bind(this);
       this.state = {
-        data: selectData(DataSource, props)
+        data: selectData(DataSource, props),
       };
     }
 
@@ -267,7 +267,7 @@ export function withSubscription<T, P extends WithDataProps<T>, C>(
 
     handleChange = () =>
       this.setState({
-        data: selectData(DataSource, this.props)
+        data: selectData(DataSource, this.props),
       });
 
     render() {
@@ -342,12 +342,12 @@ type CommentType = { text: string; id: number };
 const comments: CommentType[] = [
   {
     text: "comment1",
-    id: 1
+    id: 1,
   },
   {
     text: "comment2",
-    id: 2
-  }
+    id: 2,
+  },
 ];
 /** dummy child components that take anything */
 const Comment = (_: any) => null;
@@ -367,10 +367,11 @@ function CommentList({ data }: WithSubscriptionProps<typeof comments>) {
 
 ```tsx
 const commentSelector = (_: any, ownProps: any) => ({
-  id: ownProps.id
+  id: ownProps.id,
 });
 const commentActions = () => ({
-  addComment: (str: string) => comments.push({ text: str, id: comments.length })
+  addComment: (str: string) =>
+    comments.push({ text: str, id: comments.length }),
 });
 
 const ConnectedComment = connect(commentSelector, commentActions)(CommentList);
@@ -380,7 +381,7 @@ interface WithSubscriptionProps<T> {
   data: T;
 }
 function connect(mapStateToProps: Function, mapDispatchToProps: Function) {
-  return function<T, P extends WithSubscriptionProps<T>, C>(
+  return function <T, P extends WithSubscriptionProps<T>, C>(
     WrappedComponent: React.ComponentType<T>
   ) {
     type Props = JSX.LibraryManagedAttributes<C, Omit<P, "data">>;
@@ -502,10 +503,10 @@ So how do we type `withOwner`?
 
 ```tsx
 function withOwner(owner: string) {
-  return function<T extends { owner: string }>(
+  return function <T extends { owner: string }>(
     Component: React.ComponentType<T>
   ) {
-    return function(props: Omit<T, "owner">): React.ReactNode {
+    return function (props: Omit<T, "owner">): React.ReactNode {
       return <Component owner={owner} {...props} />;
     };
   };

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Some differences from the "normal function" version:
 ```tsx
 const Title: React.FunctionComponent<{ title: string }> = ({
   children,
-  title
+  title,
 }) => <div title={title}>{children}</div>;
 ```
 
@@ -326,12 +326,12 @@ export function reducer(state: AppState, action: Action): AppState {
     case "SET_ONE":
       return {
         ...state,
-        one: action.payload // `payload` is string
+        one: action.payload, // `payload` is string
       };
     case "SET_TWO":
       return {
         ...state,
-        two: action.payload // `payload` is number
+        two: action.payload, // `payload` is number
       };
     default:
       return state;
@@ -433,7 +433,7 @@ type MyState = {
 class App extends React.Component<MyProps, MyState> {
   state: MyState = {
     // optional second annotation for better type inference
-    count: 0
+    count: 0,
   };
   render() {
     return (
@@ -492,8 +492,8 @@ class App extends React.Component<{ message: string }, { count: number }> {
   }
   increment = (amt: number) => {
     // like this
-    this.setState(state => ({
-      count: state.count + amt
+    this.setState((state) => ({
+      count: state.count + amt,
     }));
   };
 }
@@ -535,7 +535,7 @@ For Typescript 3.0+, type inference [should work](https://www.typescriptlang.org
 // ////////////////
 type Props = { age: number } & typeof defaultProps;
 const defaultProps = {
-  who: "Johny Five"
+  who: "Johny Five",
 };
 
 const Greet = (props: Props) => {
@@ -553,7 +553,7 @@ type GreetProps = typeof Greet.defaultProps & {
 
 class Greet extends React.Component<GreetProps> {
   static defaultProps = {
-    name: "world"
+    name: "world",
   };
   /*...*/
 }
@@ -587,7 +587,7 @@ type Props = Required<typeof MyComponent.defaultProps> & {
 
 export class MyComponent extends React.Component<Props> {
   static defaultProps = {
-    foo: "foo"
+    foo: "foo",
   };
 }
 ```
@@ -602,7 +602,7 @@ interface IMyComponentProps {
 
 export class MyComponent extends React.Component<IMyComponentProps> {
   public static defaultProps: Partial<IMyComponentProps> = {
-    firstProp: "default"
+    firstProp: "default",
   };
 }
 ```
@@ -749,7 +749,7 @@ type State = DefinedState & ReturnType<typeof transformPropsToState>;
 function transformPropsToState(props: Props) {
   return {
     savedPropA: props.propA, // save for memoization
-    derivedState: props.propA
+    derivedState: props.propA,
   };
 }
 class Comp extends React.PureComponent<Props, State> {
@@ -757,7 +757,7 @@ class Comp extends React.PureComponent<Props, State> {
     super(props);
     this.state = {
       otherStateField: "123",
-      ...transformPropsToState(props)
+      ...transformPropsToState(props),
     };
   }
   static getDerivedStateFromProps(props: Props, state: State) {
@@ -776,7 +776,7 @@ If performance is not an issue, inlining handlers is easiest as you can just use
 ```tsx
 const el = (
   <button
-    onClick={event => {
+    onClick={(event) => {
       /* ... */
     }}
   />
@@ -794,7 +794,7 @@ class App extends React.Component<
   }
 > {
   state = {
-    text: ""
+    text: "",
   };
 
   // typing on RIGHT hand side of =
@@ -914,7 +914,7 @@ export function createCtx<A>(defaultValue: A) {
   const defaultUpdate: UpdateType = () => defaultValue;
   const ctx = React.createContext({
     state: defaultValue,
-    update: defaultUpdate
+    update: defaultUpdate,
   });
   function Provider(props: React.PropsWithChildren<{}>) {
     const [state, update] = React.useState(defaultValue);
@@ -939,7 +939,7 @@ export function Component() {
   return (
     <label>
       {state}
-      <input type="text" onChange={e => update(e.target.value)} />
+      <input type="text" onChange={(e) => update(e.target.value)} />
     </label>
   );
 }
@@ -974,7 +974,7 @@ const Context = React.createContext({} as ProviderStore); // type assertion on e
 
 class Provider extends React.Component<{}, ProviderState> {
   public readonly state = {
-    themeColor: "red"
+    themeColor: "red",
   };
 
   private update = ({ key, value }: UpdateStateArg) => {
@@ -984,7 +984,7 @@ class Provider extends React.Component<{}, ProviderState> {
   public render() {
     const store: ProviderStore = {
       state: this.state,
-      update: this.update
+      update: this.update,
     };
 
     return (
@@ -1102,14 +1102,14 @@ class App extends React.Component<
   }
 > {
   state = {
-    count: null
+    count: null,
   };
   render() {
     return <div onClick={() => this.increment(1)}>{this.state.count}</div>;
   }
   increment = (amt: number) => {
-    this.setState(state => ({
-      count: (state.count || 0) + amt
+    this.setState((state) => ({
+      count: (state.count || 0) + amt,
     }));
   };
 }
@@ -1176,7 +1176,7 @@ Enums in TypeScript default to numbers. You will usually want to use them as str
 export enum ButtonSizes {
   default = "default",
   small = "small",
-  large = "large"
+  large = "large",
 }
 ```
 
@@ -1343,7 +1343,7 @@ Fortunately, with `typeof`, you won't have to do that. Just use it on any value:
 ```tsx
 const [state, setState] = React.useState({
   foo: 1,
-  bar: 2
+  bar: 2,
 }); // state's type inferred to be {foo: number, bar: number}
 
 const someMethod = (obj: typeof state) => {
@@ -1360,7 +1360,7 @@ Working with slicing state and props is common in React. Again, you don't really
 ```tsx
 const [state, setState] = React.useState({
   foo: 1,
-  bar: 2
+  bar: 2,
 }); // state's type inferred to be {foo: number, bar: number}
 
 // NOTE: stale state merging is not actually encouraged in React.useState
@@ -1391,7 +1391,7 @@ This can be annoying but here are ways to grab the types!
 import { Button } from "library"; // but doesn't export ButtonProps! oh no!
 type ButtonProps = React.ComponentProps<typeof Button>; // no problem! grab your own!
 type AlertButtonProps = Omit<ButtonProps, "onClick">; // modify
-const AlertButton: React.FC<AlertButtonProps> = props => (
+const AlertButton: React.FC<AlertButtonProps> = (props) => (
   <Button onClick={() => alert("hello")} {...props} />
 );
 ```
@@ -1420,9 +1420,9 @@ function foo() {
     subInstArr: [
       {
         c: 3,
-        d: 4
-      }
-    ]
+        d: 4,
+      },
+    ],
   };
 }
 
@@ -1432,7 +1432,7 @@ type SubIsntType = SubInstArr[0];
 
 let baz: SubIsntType = {
   c: 5,
-  d: 6 // type checks ok!
+  d: 6, // type checks ok!
 };
 
 //You could just write a one-liner,
@@ -1441,7 +1441,7 @@ let baz: SubIsntType = {
 type SubIsntType2 = ReturnType<typeof foo>["subInstArr"][0];
 let baz2: SubIsntType2 = {
   c: 5,
-  d: 6 // type checks ok!
+  d: 6, // type checks ok!
 };
 ```
 
@@ -1605,8 +1605,8 @@ declare let process: {
 };
 process = {
   env: {
-    NODE_ENV: "production"
-  }
+    NODE_ENV: "production",
+  },
 };
 ```
 
@@ -1678,14 +1678,14 @@ module.exports = {
   env: {
     es6: true,
     node: true,
-    jest: true
+    jest: true,
   },
   extends: "eslint:recommended",
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: "module"
+    sourceType: "module",
   },
   rules: {
     indent: ["error", 2],
@@ -1695,11 +1695,11 @@ module.exports = {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
-      { vars: "all", args: "after-used", ignoreRestSiblings: false }
+      { vars: "all", args: "after-used", ignoreRestSiblings: false },
     ],
     "@typescript-eslint/explicit-function-return-type": "warn", // Consider using explicit annotations for object literals and function return types even when they can be inferred.
-    "no-empty": "warn"
-  }
+    "no-empty": "warn",
+  },
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/typescript-cheatsheets/react-typescript-cheatsheet#readme",
   "devDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==


### PR DESCRIPTION
Follow-up to #201. Prettier 2.0 was released in the meantime which means it can now run on the complete file (stopped previously at typescripts `import type` syntax).

I hope the bot can handle 2.x