### PR TITLE
chore: remove repository name filter

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,14 +5,10 @@ on:
     paths:
       - "website/**"
       - "docs/**"
-  pull_request:
-    branches: [master]
 
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
-    # TODO: Change this before merge
-    if: github.repository == 'raulfdm/react-typescript-cheatsheet'
 
     env:
       working-directory: website


### PR DESCRIPTION
Before I was filtering to my repo name. I think now it makes sense to remove this filter and only run when it push