### PR TITLE
docs(hoc) Use Omit instead of Optionalize

### DIFF
--- a/docs/hoc/full-example.md
+++ b/docs/hoc/full-example.md
@@ -61,7 +61,7 @@ export function withTheme<T extends WithThemeProps = WithThemeProps>(
 
   // Creating the inner component. The calculated Props type here is the where the magic happens.
   return class ComponentWithTheme extends React.Component<
-    Optionalize<T, WithThemeProps>
+    Omit<T, keyof WithThemeProps>
   > {
     public static displayName = `withTheme(${displayName})`;
 
@@ -77,8 +77,6 @@ export function withTheme<T extends WithThemeProps = WithThemeProps>(
 ```
 
 Note that the `{...this.props as T}` assertion is needed because of a current bug in TS 3.2 https://github.com/Microsoft/TypeScript/issues/28938#issuecomment-450636046
-
-For `Optionalize` details check out the [utility types section](https://github.com/typescript-cheatsheets/typescript-utilities-cheatsheet#utility-types).
 
 Here is a more advanced example of a dynamic higher order component that bases some of its parameters on the props of the component being passed in:
 


### PR DESCRIPTION
Omit is now officially part of TypeScript (since v3.5)