### PR TITLE
Fix site url link color

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -51,6 +51,7 @@ const siteConfig = {
   colors: {
     primaryColor: "#222222",
     secondaryColor: "#171717",
+    urlColor: "#138cd3",
   },
 
   /* Custom fonts for website */

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -40,3 +40,11 @@
 .nav-footer {
   background: #222;
 }
+
+.container a:not(.button) {
+  color: $urlColor;
+}
+
+.container a:not(.button):hover {
+  opacity: 0.75;
+}

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -36,9 +36,8 @@
   flex-grow: 1;
 }
 
-/* TODO: get it from siteConfig */
 .nav-footer {
-  background: #222;
+  background: $primaryColor;
 }
 
 .container a:not(.button) {


### PR DESCRIPTION
### Description
This PR fixes link color which currently hard to distinguish between url link and the rest of paragraph. Speaking of the hex code, I'm taking it from the logo just to match website's color pallete. Also, I changed `.nav-footer` background color to `primaryColor` variable from `siteConfig`

### Actual Behaviour
![Screenshot_2020-04-30 Setup · React TypeScript Cheatsheets(3)](https://user-images.githubusercontent.com/33394747/80676714-8f9e1c80-8ae1-11ea-9c1d-2d132eeee2cb.png)

### Expected Behaviour
![Screenshot_2020-04-30 Setup · React TypeScript Cheatsheets(2)](https://user-images.githubusercontent.com/33394747/80676942-0f2beb80-8ae2-11ea-9e3e-22a1a2403d39.png)
