### PR TITLE
Update example for children type that accepts anything

### DIFF
--- a/docs/basic/getting-started/react-prop-type-examples.md
+++ b/docs/basic/getting-started/react-prop-type-examples.md
@@ -9,7 +9,7 @@ export declare interface AppProps {
   children2: JSX.Element | JSX.Element[]; // meh, doesn't accept strings
   children3: React.ReactChildren; // despite the name, not at all an appropriate type; it is a utility
   children4: React.ReactChild[]; // better
-  children: React.ReactNode; // best, accepts everything
+  children: React.ReactNode | React.ReactNode[]; // best, accepts everything
   functionChildren: (name: string) => React.ReactNode; // recommended function as a child render prop type
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target


### PR DESCRIPTION
The current docs seems to indicate that `React.ReactNode` includes everything, including arrays. However, it does not include arrays. 

So this updates the docs for the children type to be `React.ReactNode | React.ReactNode[]` which does indeed include everything.

Here's the actual type def for `ReactNode`:

```tsx
type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
```

[source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L238)