### PR TITLE
Revert "Update example for children type that accepts anything"

### DIFF
--- a/docs/basic/getting-started/react-prop-type-examples.md
+++ b/docs/basic/getting-started/react-prop-type-examples.md
@@ -9,7 +9,7 @@ export declare interface AppProps {
   children2: JSX.Element | JSX.Element[]; // meh, doesn't accept strings
   children3: React.ReactChildren; // despite the name, not at all an appropriate type; it is a utility
   children4: React.ReactChild[]; // better
-  children: React.ReactNode | React.ReactNode[]; // best, accepts everything
+  children: React.ReactNode; // best, accepts everything
   functionChildren: (name: string) => React.ReactNode; // recommended function as a child render prop type
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target


### PR DESCRIPTION
Reverts typescript-cheatsheets/react-typescript-cheatsheet#240

`type ReactFragment = {} | ReactNodeArray;`
`interface ReactNodeArray extends Array<ReactNode> {}`

so 

`type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;`
becomes
`type ReactNode = ReactChild | {} | Array<ReactNode> | ReactPortal | boolean | null | undefined;`

I think we should revert this. @flybayer Was there a particular pattern that you wanted to enable?
