### PR TITLE
fix(advanced): remove typo from component type

### DIFF
--- a/docs/advanced/guides/type-component-diff-props.md
+++ b/docs/advanced/guides/type-component-diff-props.md
@@ -83,7 +83,7 @@ interface Button {
   as: React.ComponentClass | "a";
 }
 
-const Button: React.FunctionComgetOrElseponent<Button> = (props) => {
+const Button: React.FunctionComponent<Button> = (props) => {
   const { as: Component, children, ...rest } = props;
   return (
     <Component className="button" {...rest}>


### PR DESCRIPTION
This PR removes text that appears to have been accidentally pasted in the middle of a type.