### PR TITLE
fix(docs): fixes hoc cheatsheet link in guides section

### DIFF
--- a/docs/advanced/guides/hocs.md
+++ b/docs/advanced/guides/hocs.md
@@ -3,4 +3,4 @@ id: hocs
 title: Higher Order Components (HOCs)
 ---
 
-**There is now a dedicated [HOC cheatsheet](./HOC.md) you can refer to get some practice on HOCs.**
+**There is now a dedicated [HOC cheatsheet](../../hoc/index.md) you can refer to get some practice on HOCs.**


### PR DESCRIPTION
Addresses concerns presented in #239 

This change fixes the `HOC cheatsheet` link broken on [this page](https://react-typescript-cheatsheet.netlify.app/docs/advanced/guides/hocs). Currently it is a broken link and I fixed it by pointing to the intro of the HOC section.