### PR TITLE
Add usage with Reducer<State, Action> utility from redux for writing …

### DIFF
--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -131,6 +131,22 @@ export function reducer(state: AppState, action: Action): AppState {
 
 [View in the TypeScript Playground](https://www.typescriptlang.org/play/?jsx=2#code/C4TwDgpgBAgmYGVgENjQLxQN4F8CwAUKJLAMbACWA9gHZTqFRQA+2UxEAXFAEQICiAFQD6AeQBy-HgG4oYZCAA2VZABNuAZ2AAnCjQDmUfASass7cF14CRggOqiZchcrXcaAVwC2AIwjajaUJCCAAPMCptYCgAMw8acmo6bQhVD1J-AAotVCs4RBQ0ABooZETabhhymgBKSvgkXOxGKA0AdwpgUgALKEyyyloAOg4a5pMmKFJkDWg+ITFJHk4WyagU4A9tOixVtaghw5zivbXaKwGkofklFVUoAHoHqAADG9dVF6gKDVadPX0p0Ce2ms2sC3sjhWEzWGy2OyBTEOQ2OECKiPYbSo3Euw3ed0ezzeLjuXx+UE8vn8QJwQRhUFUEBiyA8imA0P26wgm22f1ydKYxhwQA)
 
+<details>
+
+<summary><b>Usage with `Reducer` from `redux`</b></summary>
+
+In case you use the [redux](https://github.com/reduxjs/redux) library to write reducer function, It provides a convenient helper of the format `Reducer<State, Action>` which takes care of the return type for you.
+
+So the above reducer example becomes:
+
+```tsx
+import { Reducer } from 'redux';
+
+export function reducer: Reducer<AppState, Action>() {}
+```
+
+</details>
+
 **Custom Hooks**
 
 If you are returning an array in your Custom Hook, you will want to avoid type inference as TypeScript will infer a union type (when you actually want different types in each position of the array). Instead, use [TS 3.4 const assertions](https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/#const-assertions):


### PR DESCRIPTION
#### What ?
**Issue:** https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/248
**Brief:** Add documentation for usage with `Reducer` from `redux` for writing reducer functions.

**Rendered as:**
<img width="905" alt="Screenshot 2020-07-14 at 2 25 28 PM" src="https://user-images.githubusercontent.com/8057916/87406436-56ecea00-c5de-11ea-9387-9e7dc7d721b3.png">
