### PR TITLE
Clarify how to type the dispatch function from useReducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,19 @@ export function reducer(state: AppState, action: Action): AppState {
 }
 ```
 
+Setting the type for `dispatch` function:
+
+```tsx
+import { Dispatch } from "react"
+import { Action } from "./reducer"
+
+
+const handleClick = (dispatch: Dispatch<Action>) => {
+  dispatch({type: "SET_ONE", payload: "some string"})
+}
+
+```
+
 [View in the TypeScript Playground](https://www.typescriptlang.org/play/?jsx=2#code/C4TwDgpgBAgmYGVgENjQLxQN4F8CwAUKJLAMbACWA9gHZTqFRQA+2UxEAXFAEQICiAFQD6AeQBy-HgG4oYZCAA2VZABNuAZ2AAnCjQDmUfASass7cF14CRggOqiZchcrXcaAVwC2AIwjajaUJCCAAPMCptYCgAMw8acmo6bQhVD1J-AAotVCs4RBQ0ABooZETabhhymgBKSvgkXOxGKA0AdwpgUgALKEyyyloAOg4a5pMmKFJkDWg+ITFJHk4WyagU4A9tOixVtaghw5zivbXaKwGkofklFVUoAHoHqAADG9dVF6gKDVadPX0p0Ce2ms2sC3sjhWEzWGy2OyBTEOQ2OECKiPYbSo3Euw3ed0ezzeLjuXx+UE8vn8QJwQRhUFUEBiyA8imA0P26wgm22f1ydKYxhwQA)
 
 **Custom Hooks**


### PR DESCRIPTION
This method will correctly type the dispatch function and utilize the `Action`  type.