### PR TITLE
Update deprecated link of prerequisites

### DIFF
--- a/docs/basic/setup.md
+++ b/docs/basic/setup.md
@@ -6,7 +6,7 @@ title: Setup TypeScript with React
 ## Prerequisites
 
 1. good understanding of [React](https://reactjs.org)
-2. familiarity with [TypeScript Types](https://www.typescriptlang.org/docs/handbook/basic-types.html) ([2ality's guide](http://2ality.com/2018/04/type-notation-typescript.html) is helpful. If you’re an absolute beginner in TypeScript, check out [chibicode’s tutorial](https://ts.chibicode.com/todo/).)
+2. familiarity with [TypeScript Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) ([2ality's guide](http://2ality.com/2018/04/type-notation-typescript.html) is helpful. If you’re an absolute beginner in TypeScript, check out [chibicode’s tutorial](https://ts.chibicode.com/todo/).)
 3. having read [the TypeScript section in the official React docs](https://reactjs.org/docs/static-type-checking.html#typescript).
 4. having read [the React section of the new TypeScript playground](http://www.typescriptlang.org/play/index.html?jsx=2&esModuleInterop=true&e=181#example/typescript-with-react) (optional: also step through the 40+ examples under [the playground's](http://www.typescriptlang.org/play/index.html) Examples section)
 


### PR DESCRIPTION
### Old [link](https://www.typescriptlang.org/docs/handbook/basic-types.html) is deprecated as you can see on the header of the page or on the image bellow: 

![image](https://user-images.githubusercontent.com/60414217/131133206-7a7fbd98-c746-435a-b157-170aba84674e.png)

#### Here is the new [link](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) if needed.