### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/readme.js.yml
+++ b/.github/workflows/readme.js.yml
@@ -1,6 +1,6 @@
 name: Generate README
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   pull_request:
     paths: "docs/basic/*"
     branches: [main]
@@ -15,7 +15,9 @@ jobs:
       - uses: franzdiebold/github-env-vars-action@v2.1.0
 
       - name: Setup Node.js Environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
 
       - name: Install dependencies
         run: npm i


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
