### PR TITLE
Add deprecation info for FormEvent and FormEventHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,6 +1379,8 @@ The first method uses an inferred method signature `(e: React.FormEvent<HTMLInpu
 
 </details>
 
+> Starting with React v19.2.10 `FormEvent` and `FormEventHandler` are deprecated and should be replaced with `SubmitEvent` and `SubmitEventHandler`. The older event types will still work but trigger a deprecation message.
+
 **Typing onSubmit, with Uncontrolled components in a Form**
 
 If you don't quite care about the type of the event, you can just use `React.SyntheticEvent`. If your target form has custom named inputs that you'd like to access, you can use a type assertion:

--- a/docs/basic/getting-started/forms-and-events.md
+++ b/docs/basic/getting-started/forms-and-events.md
@@ -61,7 +61,6 @@ The first method uses an inferred method signature `(e: React.FormEvent<HTMLInpu
 
 > Starting with React v19.2.10 `FormEvent` and `FormEventHandler` are deprecated and should be replaced with `SubmitEvent` and `SubmitEventHandler`. The older event types will still work but trigger a deprecation message.
 
-
 **Typing onSubmit, with Uncontrolled components in a Form**
 
 If you don't quite care about the type of the event, you can just use `React.SyntheticEvent`. If your target form has custom named inputs that you'd like to access, you can use a type assertion:

--- a/docs/basic/getting-started/forms-and-events.md
+++ b/docs/basic/getting-started/forms-and-events.md
@@ -59,6 +59,9 @@ The first method uses an inferred method signature `(e: React.FormEvent<HTMLInpu
 
 </details>
 
+> Starting with React v19.2.10 `FormEvent` and `FormEventHandler` are deprecated and should be replaced with `SubmitEvent` and `SubmitEventHandler`. The older event types will still work but trigger a deprecation message.
+
+
 **Typing onSubmit, with Uncontrolled components in a Form**
 
 If you don't quite care about the type of the event, you can just use `React.SyntheticEvent`. If your target form has custom named inputs that you'd like to access, you can use a type assertion:


### PR DESCRIPTION
Hello,
This small change addresses the recent deprecation of `FormEvent` and `FormEventHandler` introduced in [DefinitelyTyped/DefinitelyTyped#74383](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74383). The deprecation appears to trigger warnings, as reported in this thread: https://github.com/remix-run/react-router/issues/14795

I’ve used the version number that was referenced in this stackoverflow discussion:
https://stackoverflow.com/questions/68326000/cant-assign-submit-event-type

Cheers