### PR TITLE
fix: correct papayawhip CSS color typo and grammar error in Context s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1553,7 +1553,7 @@ const useCurrentUser = () => {
 };
 ```
 
-Using a runtime type check in this will has the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
+Using a runtime type check in this will have the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
 
 ```tsx
 import { useContext } from "react";
@@ -1913,7 +1913,7 @@ function App() {
           >
             I'm a modal!{" "}
             <button
-              style={{ background: "papyawhip" }}
+              style={{ background: "papayawhip" }}
               onClick={() => setShowModal(false)}
             >
               close


### PR DESCRIPTION
…ection

Corrected grammatical errors in the documentation to enhance clarity.

Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
