### PR TITLE
docs: fix papayawhip typo and context section grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1553,7 +1553,7 @@ const useCurrentUser = () => {
 };
 ```
 
-Using a runtime type check in this will has the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
+Using a runtime type check in this will have the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
 
 ```tsx
 import { useContext } from "react";
@@ -1913,7 +1913,7 @@ function App() {
           >
             I'm a modal!{" "}
             <button
-              style={{ background: "papyawhip" }}
+              style={{ background: "papayawhip" }}
               onClick={() => setShowModal(false)}
             >
               close

--- a/docs/basic/getting-started/context.md
+++ b/docs/basic/getting-started/context.md
@@ -107,7 +107,7 @@ const useCurrentUser = () => {
 };
 ```
 
-Using a runtime type check in this will has the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
+Using a runtime type check in this will have the benefit of printing a clear error message in the console when a provider is not wrapping the components properly. Now it's possible to access `currentUser.username` without checking for `null`:
 
 ```tsx
 import { useContext } from "react";

--- a/docs/basic/getting-started/portals.md
+++ b/docs/basic/getting-started/portals.md
@@ -90,7 +90,7 @@ function App() {
           >
             I'm a modal!{" "}
             <button
-              style={{ background: "papyawhip" }}
+              style={{ background: "papayawhip" }}
               onClick={() => setShowModal(false)}
             >
               close


### PR DESCRIPTION
Hello! I've noticed a couple of minor errors while going through the documentation:

**1. Typo in Portals:** Corrected papyawhip to papayawhip in docs/basic/getting-started/portals.md.

**2. Grammar in Context:** Fixed "will has" to "will have" in docs/basic/getting-started/context.md.

I have made these edits directly in the /docs/basic source files as requested to ensure the auto-generation works correctly.